### PR TITLE
Fix: load velocity weights at inference in predict.py

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -224,6 +224,8 @@ if __name__ == "__main__":
 
     # 2. Load initial velocity and constitutive models
     model = Estimator(position, cfg, dat, opt, ppl, phy)
+    model.load_weights(dat.model_path, iteration=arg.load_iter, phase="velocity")
+    print(f"velocity loaded: {model.velocity.tolist()}")
     resume_path = model.load_weights(dat.model_path, iteration=arg.load_iter, phase="constitution")
     print(f"constitution parameters loaded from {resume_path}")
 


### PR DESCRIPTION
## Summary

Fixes #2.

`predict.py` was loading only `phase="constitution"` and silently skipping `phase="velocity"`, so `model.velocity` stayed at the `Estimator.__init__` default at inference time. MPM then rolled out from an uninformed initial velocity, corrupting every downstream metric (CD, PSNR, SSIM) and producing black renders.

This PR adds the missing two-line load between `Estimator(...)` and the constitution load, exactly as proposed in the issue:

```diff
     # 2. Load initial velocity and constitutive models
     model = Estimator(position, cfg, dat, opt, ppl, phy)
+    model.load_weights(dat.model_path, iteration=arg.load_iter, phase="velocity")
+    print(f"velocity loaded: {model.velocity.tolist()}")
     resume_path = model.load_weights(dat.model_path, iteration=arg.load_iter, phase="constitution")
     print(f"constitution parameters loaded from {resume_path}")
```

## Test plan

- [x] Verified on Genesis `0_0` single sequence, GT-direct, 20k iters: Test CD drops from ~84 to **0.072** (~1168× ↓).
- [x] Black-image renders are resolved after the fix.
- [x] See issue #2 for the full before/after metric table.